### PR TITLE
possible update for 2.33

### DIFF
--- a/api/BuildInfo.cs
+++ b/api/BuildInfo.cs
@@ -6,7 +6,7 @@
 		public const string Description = ""; // Description for the Mod.  (Set as null if none)
 		public const string Author = "BA"; // Author of the Mod.  (MUST BE SET)
 		public const string Company = null; // Company that made the Mod.  (Set as null if none)
-		public const string Version = "1.0.7"; // Version of the Mod.  (MUST BE SET)
+		public const string Version = "1.0.8"; // Version of the Mod.  (MUST BE SET)
 		public const string DownloadLink = null; // Download Link for the Mod.  (Set as null if none)
 	}
 }

--- a/api/ExamineActionState.cs
+++ b/api/ExamineActionState.cs
@@ -145,11 +145,11 @@ namespace ExamineActionsAPI
             if (Action is IExamineActionRequireTool eat)
             {
                 var pie = InterfaceManager.GetPanel<Panel_Inventory_Examine>();
-                pie.m_Tools.Clear();
-                eat.GetToolOptions(this, pie.m_Tools);
-                // for (int i = 0; i < pie.m_Tools.Count; i++)
-                // 	ExamineActionsAPI.VeryVerboseLog($"{pie.m_Tools[i]?.name} ({pie.m_Tools[i].GetInstanceID()})");
-                if (pie.m_Tools.Count == 0) // No tool
+                pie.m_RepairToolsList.m_Tools.Clear();
+                eat.GetToolOptions(this, pie.m_RepairToolsList.m_Tools);
+                // for (int i = 0; i < pie.m_RepairToolsList.m_Tools.Count; i++)
+                // 	ExamineActionsAPI.VeryVerboseLog($"{pie.m_RepairToolsList.m_Tools[i]?.name} ({pie.m_RepairToolsList.m_Tools[i].GetInstanceID()})");
+                if (pie.m_RepairToolsList.m_Tools.Count == 0) // No tool
                 {
                     ActiveActionRequirementsMet = false;
                 }

--- a/api/ExamineActionsAPI.cs
+++ b/api/ExamineActionsAPI.cs
@@ -181,7 +181,7 @@ namespace ExamineActionsAPI
 			{
 				if (State.SelectingTool)
 				{
-					VeryVerboseLog($"GetSelectedTool {pie.GetSelectedTool()?.name}");
+					VeryVerboseLog($"GetSelectedTool {pie.m_RepairToolsList.GetSelectedTool()?.name}");
 					State.SelectingTool = false;
 					State.Panel.OnToolSelected(State);
 					State.PanelExtension?.OnToolSelected(State);
@@ -193,7 +193,7 @@ namespace ExamineActionsAPI
 					State.SelectingTool = true;
 					State.Panel.OnSelectingTool(State);
 					State.PanelExtension?.OnSelectingTool(State);
-					pie.SelectWindow(pie.m_ActionToolSelect);
+					pie.SelectWindow(pie.GetActionToolSelect());
 				}
 			}
 			else
@@ -298,7 +298,7 @@ namespace ExamineActionsAPI
 
 			if (State.Action is IExamineActionRequireTool toolUser)
 			{
-				GameObject selectedTool = pie.GetSelectedTool();
+				GameObject selectedTool = pie.m_RepairToolsList.GetSelectedTool();
 				var degrade = selectedTool?.GetComponent<GearItem>()?.m_DegradeOnUse;
 				if (degrade)
 				{

--- a/api/ExamineActionsAPI.csproj
+++ b/api/ExamineActionsAPI.csproj
@@ -29,7 +29,7 @@
     <!--This tells the compiler where to look for assemblies. Don't change it.-->
     <PropertyGroup>
         <!--This needs to be changed for the mod to compile.-->
-        <TheLongDarkPath>..\..\..\</TheLongDarkPath>
+        <TheLongDarkPath>C:\Program Files (x86)\Steam\steamapps\common\TheLongDark</TheLongDarkPath>
         <MelonLoaderPath>$(TheLongDarkPath)/MelonLoader/net6</MelonLoaderPath>
         <ManagedPath>$(TheLongDarkPath)/MelonLoader/Managed</ManagedPath>
         <Il2CppPath>$(TheLongDarkPath)/MelonLoader/Il2CppAssemblies</Il2CppPath>
@@ -46,64 +46,10 @@
             <Private>False</Private>
         </Reference>
     </ItemDefinitionGroup>
+    <ItemGroup>
+      <PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.33.0" />
+    </ItemGroup>
 
     <!--This is the list of assemblies that the mod references. Most of these are unnecessary for normal mods, but are included here for completeness.-->
-    <ItemGroup>
-        <Reference Include="Il2CppInterop.Common">
-          <HintPath>..\..\..\MelonLoader\net6\Il2CppInterop.Common.dll</HintPath>
-        </Reference>
-        <Reference Include="Il2CppInterop.Runtime">
-          <HintPath>..\..\..\MelonLoader\net6\Il2CppInterop.Runtime.dll</HintPath>
-        </Reference>
-        <Reference Include="MelonLoader" />
-        <Reference Include="0Harmony" />
-        <Reference Include="Assembly-CSharp" />
-        <Reference Include="Il2CppHOTween" />
-        <Reference Include="Il2Cppmscorlib" />
-        <Reference Include="Il2CppNewtonsoft.Json" />
-        <Reference Include="Il2CppSystem.Configuration" />
-        <Reference Include="Il2CppSystem" />
-        <Reference Include="Il2CppSystem.Runtime.Serialization" />
-        <Reference Include="Il2CppTLD.Addressables" />
-        <Reference Include="Il2CppTLD.Encryption" />
-        <Reference Include="Il2CppTLD.Game.Events.Runtime" />
-        <Reference Include="Il2CppTLD.GameplayTag" />
-        <Reference Include="Il2CppTLD.IO" />
-        <Reference Include="Il2CppTLD.Logging" />
-        <Reference Include="Il2CppTLD.OptionalContent" />
-        <Reference Include="Il2CppTLD.PDID" />
-        <Reference Include="Il2CppTLD.Platform" />
-        <Reference Include="Il2CppTLD.Profiling" />
-        <Reference Include="Il2CppTLD.RuntimeTest" />
-        <Reference Include="Il2CppTLD.SaveState" />
-        <Reference Include="Il2CppTLD.Serialization" />
-        <Reference Include="Il2CppTLD.Stats" />
-        <Reference Include="Il2CppTLD.IntBackedUnit" />
-        <Reference Include="Il2CppTLD.TimeLib" />
-        <Reference Include="Il2CppTLD.Trial" />
-        <Reference Include="Il2CppTLD.UserGeneratedContent" />
-        <Reference Include="Il2CppAk.Wwise.Api.WAAPI" />
-        <Reference Include="Il2CppAK.Wwise.Unity.API" />
-        <Reference Include="Il2CppAK.Wwise.Unity.API.WwiseTypes" />
-        <Reference Include="Il2CppAK.Wwise.Unity.MonoBehaviour" />
-        <Reference Include="Il2CppAK.Wwise.Unity.Timeline" />
-        <Reference Include="Unity.Mathematics" />
-        <Reference Include="Unity.TextMeshPro" />
-        <Reference Include="UnityEngine.AssetBundleModule" />
-        <Reference Include="UnityEngine.CoreModule" />
-        <Reference Include="UnityEngine" />
-        <Reference Include="UnityEngine.InputLegacyModule" />
-        <Reference Include="UnityEngine.InputModule" />
-        <Reference Include="UnityEngine.Il2CppAssetBundleManager" />
-        <Reference Include="UnityEngine.Il2CppImageConversionManager" />
-        <Reference Include="Unity.Addressables" />
-        <Reference Include="Unity.ResourceManager" />
-        <Reference Include="UnityEngine.PhysicsModule">
-          <HintPath>..\..\..\MelonLoader\Il2CppAssemblies\UnityEngine.PhysicsModule.dll</HintPath>
-        </Reference>
-        <Reference Include="KeyboardUtilities" />
-    </ItemGroup>
-    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-        <Exec Command="xcopy /y /d  &quot;$(TargetPath)&quot; &quot;$(TheLongDarkPath)\Mods&quot;" />
-    </Target>
+
 </Project>

--- a/api/Patches/PatchInitialize.cs
+++ b/api/Patches/PatchInitialize.cs
@@ -5,41 +5,44 @@ using UnityEngine;
 
 namespace ExamineActionsAPI
 {
-    [HarmonyPatch(typeof(Panel_Inventory_Examine), nameof(Panel_Inventory_Examine.Initialize))]
-    internal class PatchInitialize
-    {
+	[HarmonyPatch(typeof(Panel_Repair), nameof(Panel_Repair.Initialize))]
+	internal class PatchInitialize
+	{
 		internal const int CUSTOM_MENU_ITEM_COUNT = 7;
-        private static void Postfix(Panel_Inventory_Examine __instance)
-        {
+		private static void Postfix(Panel_Repair __instance)
+		{
+			var pie = InterfaceManager.GetPanel<Panel_Inventory_Examine>();
 			ExamineActionsAPI.VeryVerboseLog($"+Initialize");
-			foreach (var it in __instance.m_ButtonsMenuItems)
+			foreach (var it in pie.m_ButtonsMenuItems)
 				ExamineActionsAPI.Instance.OfficialActionMenuItems.Add(it);
 			for (int i = 0; i < CUSTOM_MENU_ITEM_COUNT; i++)
 			{
 				var capturedId = i;
-				var mi = GameObject.Instantiate(__instance.m_MenuItemRepair, __instance.m_MenuItemHarvest.transform.parent).GetComponent<Panel_Inventory_Examine_MenuItem>();
-				__instance.m_ButtonsMenuItems.Add(mi);
-				__instance.m_Buttons.Add(mi.GetComponent<UIButton>());
+				var mi = GameObject.Instantiate(pie.m_MenuItemRepair, pie.m_MenuItemHarvest.transform.parent).GetComponent<Panel_Inventory_Examine_MenuItem>();
+				pie.m_ButtonsMenuItems.Add(mi);
+				pie.m_Buttons.Add(mi.GetComponent<UIButton>());
 				ExamineActionsAPI.Instance.CustomActionMenuItems.Add(mi);
 
-                UILabel subLabel = GameObject.Instantiate<UILabel>(mi.m_LabelTitle, mi.transform);
+				UILabel subLabel = GameObject.Instantiate<UILabel>(mi.m_LabelTitle, mi.transform);
 				subLabel.fontSize -= 4;
 				subLabel.transform.localPosition -= new Vector3(0, 12, 0);
 				subLabel.color = mi.m_TextColor_Disabled;
 				GameObject.Destroy(subLabel.GetComponent<UILocalize>());
-                ExamineActionsAPI.Instance.CustomActionMenuItemSubLabels.Add(subLabel);
+				ExamineActionsAPI.Instance.CustomActionMenuItemSubLabels.Add(subLabel);
 
 				ExamineActionsAPI.VeryVerboseLog($"Instantiated menu item: {mi.name}");
 				mi.m_ButtonSpriteRef.onClick.Clear();
 				mi.gameObject.SetActive(false);
 				mi.gameObject.name = $"CustomAction{capturedId}";
 				// Action callback = new System.Action(() => OnCustomActionSelected(capturedId));
-				EventDelegate.Add(mi.m_ButtonSpriteRef.onClick, new System.Action(() => __instance.SelectButton(capturedId + ExamineActionsAPI.Instance.OfficialActionMenuItems.Count))); // Mouse click on the menu item (select)
-				__instance.m_ButtonDelegates.Add(new System.Action(ExamineActionsAPI.Instance.OnPerformSelectedAction)); // Enter pressed when the menu item selected (perform)
+				EventDelegate.Add(mi.m_ButtonSpriteRef.onClick, new System.Action(() => pie.SelectButton(capturedId + ExamineActionsAPI.Instance.OfficialActionMenuItems.Count))); // Mouse click on the menu item (select)
+				pie.m_ButtonDelegates.Add(new System.Action(ExamineActionsAPI.Instance.OnPerformSelectedAction)); // Enter pressed when the menu item selected (perform)
 			}
 
-			ExamineActionsAPI.Instance.DefaultPanel = new DefaultPanel(__instance);
+			ExamineActionsAPI.Instance.DefaultPanel = new DefaultPanel(pie, __instance);
 			ExamineActionsAPI.VeryVerboseLog($"-Initialize");
-        }
-    }
+		}
+	}
+
+
 }

--- a/api/Patches/PatchOnBack.cs
+++ b/api/Patches/PatchOnBack.cs
@@ -22,7 +22,7 @@ namespace ExamineActionsAPI
             // }
 
 			if (state.Action is IExamineActionRequireTool
-             && __instance.m_ActionToolSelect.activeInHierarchy)
+             && __instance.GetActionToolSelect().activeInHierarchy)
 			{
 				__instance.SelectWindow(__instance.m_MainWindow);
 				ExamineActionsAPI.VeryVerboseLog($"OnBack_Redirect {__instance.m_SelectedButtonIndex}");

--- a/api/Patches/PatchOnExamine.cs
+++ b/api/Patches/PatchOnExamine.cs
@@ -38,7 +38,7 @@ namespace ExamineActionsAPI
         internal static float lastExamine;
         private static void Prefix(Panel_Inventory __instance)
         {
-            LastTriedToExamine = __instance.GetCurrentlySelectedGearItem();
+            LastTriedToExamine = __instance.GetCurrentlySelectedItem().m_GearItem;
             lastExamine = Time.realtimeSinceStartup;
             ExamineActionsAPI.Instance.LastTriedToPerformedCache = null;
         }
@@ -62,8 +62,8 @@ namespace ExamineActionsAPI
         internal static float lastUse;
         private static void Prefix(Panel_Inventory __instance)
         {
-            LastTriedToUse = __instance.GetCurrentlySelectedGearItem();
-            lastUse = Time.realtimeSinceStartup;
+            LastTriedToUse = __instance.GetCurrentlySelectedItem().m_GearItem;
+			lastUse = Time.realtimeSinceStartup;
         }
     }
 }

--- a/api/Patches/PatchRefreshSelectedActionTool.cs
+++ b/api/Patches/PatchRefreshSelectedActionTool.cs
@@ -5,14 +5,14 @@ using MelonLoader;
 namespace ExamineActionsAPI
 {
     // Grab selected tool (using official tool selection window)
-    [HarmonyPatch(typeof(Panel_Inventory_Examine), nameof(Panel_Inventory_Examine.RefreshSelectedActionTool))]
+    [HarmonyPatch(typeof(ToolsList), nameof(ToolsList.RefreshSelectedActionTool))]
     internal class PatchRefreshSelectedActionTool
     {
-        private static void Prefix(Panel_Inventory_Examine __instance)
+        private static void Prefix(ToolsList __instance)
         {
 			// MelonLogger.Msg($"PRE RefreshSelectedActionTool ({__instance.m_ActionToolSelect.gameObject.activeInHierarchy} / { __instance.m_ToolScrollList.m_TargetIndex } / { __instance.m_ToolScrollList.m_SelectedIndex })");
         }
-        private static void Postfix(Panel_Inventory_Examine __instance)
+        private static void Postfix(ToolsList __instance)
         {
 			// MelonLogger.Msg($"POST RefreshSelectedActionTool ({__instance.m_ActionToolSelect.gameObject.activeInHierarchy} / { __instance.m_ToolScrollList.m_TargetIndex } / { __instance.m_ToolScrollList.m_SelectedIndex })");
             GearItem? gearItem = __instance.GetSelectedTool()?.GetComponent<GearItem>();

--- a/api/Patches/PatchSelectButton.cs
+++ b/api/Patches/PatchSelectButton.cs
@@ -26,13 +26,13 @@ namespace ExamineActionsAPI
 				
 				ExamineActionsAPI.Instance.OnCustomActionSelected(index - ExamineActionsAPI.Instance.OfficialActionMenuItems.Count);
 
-				__instance.m_ActionToolSelect.transform.FindChild("Mouse").gameObject.SetActive(false);
+				__instance.GetActionToolSelect().transform.FindChild("Mouse").gameObject.SetActive(false);
 				// __instance.m_Tool_ConfirmButtonLabel.parent.gameObject.SetActive(false);
 
 			}
 			else
 			{
-				__instance.m_ActionToolSelect.transform.FindChild("Mouse").gameObject.SetActive(true);
+				__instance.GetActionToolSelect().transform.FindChild("Mouse").gameObject.SetActive(true);
 				// __instance.m_Tool_ConfirmButtonLabel.parent.gameObject.SetActive(true);
 			}
         }

--- a/api/Patches/PatchSelectWindow.cs
+++ b/api/Patches/PatchSelectWindow.cs
@@ -14,7 +14,7 @@ namespace ExamineActionsAPI
         {
             ExamineActionsAPI.VeryVerboseLog($"++++++++POST SelectWindow {window?.name}");
             if (ExamineActionsAPI.Instance.State.Action == null) return;
-			if (window == __instance.m_ActionToolSelect) 
+			if (window == __instance.GetActionToolSelect()) 
             {
                 if (__instance.m_GearItem.m_Harvest) __instance.m_HarvestWindow.SetActive(false);
                 if (__instance.m_GearItem.m_Repairable) __instance.m_RepairPanel.SetActive(false);

--- a/demo/ThingsToDo.csproj
+++ b/demo/ThingsToDo.csproj
@@ -48,60 +48,10 @@
     </ItemDefinitionGroup>
 
     <!--This is the list of assemblies that the mod references. Most of these are unnecessary for normal mods, but are included here for completeness.-->
-    <ItemGroup>
-        <Reference Include="Il2CppInterop.Common">
-          <HintPath>..\..\..\MelonLoader\net6\Il2CppInterop.Common.dll</HintPath>
-        </Reference>
-        <Reference Include="Il2CppInterop.Runtime">
-          <HintPath>..\..\..\MelonLoader\net6\Il2CppInterop.Runtime.dll</HintPath>
-        </Reference>
-        <Reference Include="MelonLoader" />
-        <Reference Include="0Harmony" />
-        <Reference Include="Assembly-CSharp" />
-        <Reference Include="Il2CppHOTween" />
-        <Reference Include="Il2Cppmscorlib" />
-        <Reference Include="Il2CppNewtonsoft.Json" />
-        <Reference Include="Il2CppSystem.Configuration" />
-        <Reference Include="Il2CppSystem" />
-        <Reference Include="Il2CppSystem.Runtime.Serialization" />
-        <Reference Include="Il2CppTLD.Addressables" />
-        <Reference Include="Il2CppTLD.Encryption" />
-        <Reference Include="Il2CppTLD.Game.Events.Runtime" />
-        <Reference Include="Il2CppTLD.GameplayTag" />
-        <Reference Include="Il2CppTLD.IO" />
-        <Reference Include="Il2CppTLD.Logging" />
-        <Reference Include="Il2CppTLD.OptionalContent" />
-        <Reference Include="Il2CppTLD.PDID" />
-        <Reference Include="Il2CppTLD.Platform" />
-        <Reference Include="Il2CppTLD.Profiling" />
-        <Reference Include="Il2CppTLD.RuntimeTest" />
-        <Reference Include="Il2CppTLD.SaveState" />
-        <Reference Include="Il2CppTLD.Serialization" />
-        <Reference Include="Il2CppTLD.Stats" />
-        <Reference Include="Il2CppTLD.TimeLib" />
-        <Reference Include="Il2CppTLD.Trial" />
-        <Reference Include="Il2CppTLD.IntBackedUnit" />
-        <Reference Include="Il2CppTLD.UserGeneratedContent" />
-        <Reference Include="Il2CppAk.Wwise.Api.WAAPI" />
-        <Reference Include="Il2CppAK.Wwise.Unity.API" />
-        <Reference Include="Il2CppAK.Wwise.Unity.API.WwiseTypes" />
-        <Reference Include="Il2CppAK.Wwise.Unity.MonoBehaviour" />
-        <Reference Include="Il2CppAK.Wwise.Unity.Timeline" />
-        <Reference Include="Unity.Mathematics" />
-        <Reference Include="Unity.TextMeshPro" />
-        <Reference Include="UnityEngine.AssetBundleModule" />
-        <Reference Include="UnityEngine.CoreModule" />
-        <Reference Include="UnityEngine" />
-        <Reference Include="UnityEngine.InputLegacyModule" />
-        <Reference Include="UnityEngine.InputModule" />
-        <Reference Include="UnityEngine.Il2CppAssetBundleManager" />
-        <Reference Include="UnityEngine.Il2CppImageConversionManager" />
-        <Reference Include="Unity.Addressables" />
-        <Reference Include="Unity.ResourceManager" />
-        <Reference Include="UnityEngine.PhysicsModule"/>
-        <Reference Include="ExamineActionsAPI" />
-    </ItemGroup>
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
         <Exec Command="xcopy /y /d  &quot;$(TargetPath)&quot; &quot;$(TheLongDarkPath)\Mods&quot;" />
     </Target>
+    <ItemGroup>
+      <PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.33.0" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
**PR not intended for direct merge & publish**

Changed out the assembly refs to use the nuget packages, keep it or discard that bit 😄 
had to move the initialization of DefaultPanel to Panel_Repair, so we can capture both Panel_Inventory_Examine and Panel_Repair
.. as you can see some elements are no longer in PIE but still exist in panel_repair (e.g. m_RequiredMaterialCenteredX)

From my minimal testing with ThingsToDo it worked and gave me the "Field Repair" option but the material positions are a bit wonky....
[ExamineActionsAPI.zip](https://github.com/user-attachments/files/18000434/ExamineActionsAPI.zip)

Left in some debug in DefaultPanel, not sure how to test any further as I've never used it or anything that requires it

Hope this helps 👍 